### PR TITLE
Fix _get_superclass_str to handle bare dict superclasses

### DIFF
--- a/src/did/implementations/doc2sql.py
+++ b/src/did/implementations/doc2sql.py
@@ -51,8 +51,12 @@ def _get_superclass_str(doc_props):
     For DID-python style ["base", "demoA"], use directly.
     """
     # DID-python schema format: top-level 'superclasses' list of strings
-    if "superclasses" in doc_props and isinstance(doc_props["superclasses"], list):
+    if "superclasses" in doc_props and isinstance(doc_props["superclasses"], (list, dict)):
         superclasses = doc_props["superclasses"]
+        # Normalize bare dict to a single-element list (MATLAB's jsonencode
+        # unwraps single-element cell arrays into scalars).
+        if isinstance(superclasses, dict):
+            superclasses = [superclasses]
         if not superclasses:
             return ""
         names = []
@@ -70,6 +74,9 @@ def _get_superclass_str(doc_props):
 
     # NDI / MATLAB format: document_class.superclasses
     superclasses = get_field(doc_props, ["document_class.superclasses"])
+    # Normalize bare dict (single superclass from MATLAB's jsonencode)
+    if isinstance(superclasses, dict):
+        superclasses = [superclasses]
     if isinstance(superclasses, list):
         names = []
         for sc in superclasses:

--- a/src/did/implementations/doc2sql.py
+++ b/src/did/implementations/doc2sql.py
@@ -51,7 +51,9 @@ def _get_superclass_str(doc_props):
     For DID-python style ["base", "demoA"], use directly.
     """
     # DID-python schema format: top-level 'superclasses' list of strings
-    if "superclasses" in doc_props and isinstance(doc_props["superclasses"], (list, dict)):
+    if "superclasses" in doc_props and isinstance(
+        doc_props["superclasses"], (list, dict)
+    ):
         superclasses = doc_props["superclasses"]
         # Normalize bare dict to a single-element list (MATLAB's jsonencode
         # unwraps single-element cell arrays into scalars).

--- a/tests/test_doc2sql_superclass.py
+++ b/tests/test_doc2sql_superclass.py
@@ -10,15 +10,11 @@ class TestGetSuperclassStrBareDict:
     """Bare dict superclasses (from MATLAB's jsonencode) should be handled."""
 
     def test_top_level_bare_dict(self):
-        doc_props = {
-            "superclasses": {"definition": "$NDIDOCUMENTPATH/base.json"}
-        }
+        doc_props = {"superclasses": {"definition": "$NDIDOCUMENTPATH/base.json"}}
         assert _get_superclass_str(doc_props) == "base"
 
     def test_top_level_list_single(self):
-        doc_props = {
-            "superclasses": [{"definition": "$NDIDOCUMENTPATH/base.json"}]
-        }
+        doc_props = {"superclasses": [{"definition": "$NDIDOCUMENTPATH/base.json"}]}
         assert _get_superclass_str(doc_props) == "base"
 
     def test_document_class_bare_dict(self):

--- a/tests/test_doc2sql_superclass.py
+++ b/tests/test_doc2sql_superclass.py
@@ -1,0 +1,49 @@
+"""Tests for _get_superclass_str handling of bare dict superclasses.
+
+Regression tests for https://github.com/Waltham-Data-Science/NDI-python/issues/52
+"""
+
+from did.implementations.doc2sql import _get_superclass_str
+
+
+class TestGetSuperclassStrBareDict:
+    """Bare dict superclasses (from MATLAB's jsonencode) should be handled."""
+
+    def test_top_level_bare_dict(self):
+        doc_props = {
+            "superclasses": {"definition": "$NDIDOCUMENTPATH/base.json"}
+        }
+        assert _get_superclass_str(doc_props) == "base"
+
+    def test_top_level_list_single(self):
+        doc_props = {
+            "superclasses": [{"definition": "$NDIDOCUMENTPATH/base.json"}]
+        }
+        assert _get_superclass_str(doc_props) == "base"
+
+    def test_document_class_bare_dict(self):
+        doc_props = {
+            "document_class": {
+                "superclasses": {"definition": "$NDIDOCUMENTPATH/base.json"}
+            }
+        }
+        assert _get_superclass_str(doc_props) == "base"
+
+    def test_document_class_list(self):
+        doc_props = {
+            "document_class": {
+                "superclasses": [
+                    {"definition": "$NDIDOCUMENTPATH/base.json"},
+                    {"definition": "$NDIDOCUMENTPATH/demoA.json"},
+                ]
+            }
+        }
+        assert _get_superclass_str(doc_props) == "base, demoA"
+
+    def test_empty_superclasses(self):
+        doc_props = {"superclasses": []}
+        assert _get_superclass_str(doc_props) == ""
+
+    def test_no_superclasses(self):
+        doc_props = {}
+        assert _get_superclass_str(doc_props) == ""


### PR DESCRIPTION
## Summary

- Fix `_get_superclass_str()` in `doc2sql.py` to handle bare dict superclasses that arrive from MATLAB's `jsonencode` (which unwraps single-element cell arrays into scalars)
- Normalize bare dicts to single-element lists in both the top-level `superclasses` and `document_class.superclasses` code paths
- Add regression tests covering bare dict, list, empty, and missing superclass cases

## Problem

Documents with a single superclass (e.g. `base`) had their `superclasses` field encoded as a bare dict instead of a list by MATLAB's `jsonencode`. The existing code only checked for `list` types, so these documents got an empty `meta.superclass` string, causing `isa()` queries to miss them entirely. In one test dataset, 98 out of 7,221 documents were affected.

## Test plan

- [x] All 6 new tests in `tests/test_doc2sql_superclass.py` pass
- [ ] Verify with a real dataset containing MATLAB-encoded single-superclass documents

Fixes: Waltham-Data-Science/NDI-python#52

https://claude.ai/code/session_01W4C2GYKchUodXEVKnnM66T