### PR TITLE
DID-python — SQLite hardening, atomicity, wheel packaging + an honest lint gate

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,3 +51,28 @@ jobs:
 
       - name: Test with pytest
         run: pytest
+
+  wheel-smoke:
+    # A pytest run imports from the source tree, so it cannot catch missing
+    # package DATA (example_schema/*.json) in the built distribution. Build a
+    # wheel, install it into a clean environment, and construct a document from
+    # OUTSIDE the repo so a broken package-data config fails here.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: Install wheel and construct a document from outside the repo
+        run: |
+          python -m pip install dist/*.whl
+          cd "$RUNNER_TEMP"
+          python -c "from did.document import Document; Document('demoA'); Document('base'); print('wheel smoke OK')"

--- a/.github/workflows/symmetry.yml
+++ b/.github/workflows/symmetry.yml
@@ -80,6 +80,14 @@ jobs:
         run: pytest -m make_artifacts -v
 
       - name: "Step 2: Python readArtifact tests"
+        # Artifacts are produced by earlier steps in THIS job (MATLAB
+        # makeArtifacts in Step 1, Python makeArtifacts above), so a missing
+        # artifact dir/file here is a real failure, not a reason to skip green.
+        # This env var makes the readArtifact test fail hard on absence instead
+        # of skipping (skips exit 0 and let the badge go green having compared
+        # nothing across languages).
+        env:
+          DID_SYMMETRY_REQUIRE_ARTIFACTS: "1"
         run: pytest -m read_artifacts -v
 
       # --- Step 3: MATLAB readArtifacts ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,34 @@ dev = [
     "pytest",
 ]
 
+# Pin the lint rule selection.
+#
+# CI installs ruff unpinned (`pip install ruff black` in
+# .github/workflows/python-package.yml), and with no config block ruff falls
+# back to its *current* default rule set, which has widened substantially
+# since this gate was written. ruff 0.16.4 reports 59 errors on an unmodified
+# origin/main (I001, UP024, SIM*, BLE001, DTZ003, S110, RUF*, FURB*), so the
+# gate had stopped measuring the change under review and started measuring
+# toolchain drift -- and it fails on `main` itself.
+#
+# E4/E7/E9/F is ruff's own pre-widening default: the rule set this codebase
+# was actually written against. Verified with ruff 0.16.4 against a worktree
+# of origin/main (361df8d): 0 errors across src/ and tests/.
+#
+# Deliberately NOT enabled. Each of these fires on unmodified main, so each
+# needs its own dedicated cleanup commit rather than riding along with
+# unrelated work:
+#   I  -- 22 unsorted import blocks      B  -- B027 x2, B904 x2, B905 x1
+#   UP -- UP015 x8, UP024 x8             C4 -- C420 x1
+#
+# E501 is excluded on purpose rather than by oversight: black owns line
+# length. This repo pins no black config, so black formats at its own default
+# of 88 columns, and it still leaves 38 lines over 88 on main (long strings
+# and URLs it will not split). E501 and `black --check` therefore cannot both
+# be green here, whatever limit is chosen.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ authors = [
   { name = "Author", email = "vanhoosr@brandeis.edu" },
 ]
 dependencies = [
-    "numpy",
-    "pandas",
-    "portalocker",
-    "networkx",
-    "matplotlib",
+    "numpy>=1.20",
+    "pandas>=2.0,<4",
+    "portalocker>=2.0",
+    "networkx>=2.6",
+    "matplotlib>=3.5",
 ]
 requires-python = ">=3.10"
 
@@ -40,3 +40,14 @@ where = ["src"]
 
 [tool.setuptools.package-dir]
 "" = "src"
+
+# Ship the example schema/document JSON in the built distribution. Without this
+# a pip-installed `did` has no example_schema/ under site-packages, so
+# PathConstants.DEFPATH points at a nonexistent directory and Document('demoA')
+# raises FileNotFoundError. example_schema/ is a data directory (no __init__.py),
+# so packages.find does not discover it and its JSON must be declared here.
+[tool.setuptools.package-data]
+"did" = ["example_schema/**/*.json"]
+
+[tool.setuptools]
+include-package-data = true

--- a/src/did/database.py
+++ b/src/did/database.py
@@ -71,12 +71,23 @@ class Database(abc.ABC):
         # Validation logic would go here
         return self._do_get_doc_ids(branch_id)
 
-    def add_docs(self, document_objs, branch_id=None, **kwargs):
+    #: Allowed values for the ``OnDuplicate`` option, mirroring DID-matlab's
+    #: ``did.database.add_docs`` ``OnDuplicate {mustBeMember(...)} = 'error'``.
+    _ON_DUPLICATE_CHOICES = ("ignore", "warn", "error")
+
+    def add_docs(self, document_objs, branch_id=None, OnDuplicate="error", **kwargs):
         if branch_id is None:
             branch_id = self.current_branch_id
+        # Reject invalid OnDuplicate up front (mirror MATLAB mustBeMember) so a
+        # typo cannot silently fall through to default behaviour.
+        if str(OnDuplicate).lower() not in self._ON_DUPLICATE_CHOICES:
+            raise ValueError(
+                "OnDuplicate must be one of "
+                f"{self._ON_DUPLICATE_CHOICES}; got {OnDuplicate!r}."
+            )
         # Validation and other logic from the Matlab code would be ported here
         for doc in document_objs:
-            self._do_add_doc(doc, branch_id, **kwargs)
+            self._do_add_doc(doc, branch_id, OnDuplicate=OnDuplicate, **kwargs)
 
     # ... other document-related methods would follow ...
 

--- a/src/did/document.py
+++ b/src/did/document.py
@@ -145,9 +145,7 @@ class Document:
                 if "base" not in data:
                     data["base"] = {}
                 elif isinstance(data["base"], list):
-                    data["base"] = Document._field_descriptors_to_defaults(
-                        data["base"]
-                    )
+                    data["base"] = Document._field_descriptors_to_defaults(data["base"])
                 # Convert flat classname/superclasses to document_class format
                 data = Document._normalize_to_document_class(data)
                 return data

--- a/src/did/document.py
+++ b/src/did/document.py
@@ -1,9 +1,26 @@
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from . import datastructures
 from . import ido
 from .common import PathConstants
+
+
+def _utc_timestamp():
+    """Return the current UTC time as an ISO-8601 millisecond string with 'Z'.
+
+    Ported from NDI-python (ndi.fun.timestamp) with the leap-second guard.
+    ``str(datetime.utcnow())`` previously emitted a space-separated,
+    timezone-less string ('2026-07-20 22:36:19.611068') that diverges from the
+    DID-matlab UTCLeapSeconds ISO-8601 output and from base.schema.json's own
+    default ('2018-12-05T18:36:47.241Z'); a JS ``new Date()`` parses the
+    tz-less form as LOCAL time. Emit '%Y-%m-%dT%H:%M:%S.%fZ' truncated to
+    milliseconds, clamping the (theoretical) leap-second :60 to :59.999.
+    """
+    now = datetime.now(timezone.utc)
+    ts = now.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+    ts = ts.replace(":60.", ":59.999")
+    return ts + "Z"
 
 
 class Document:
@@ -13,7 +30,7 @@ class Document:
         else:
             self.document_properties = self.read_blank_definition(document_type)
             self.document_properties["base"]["id"] = ido.IDO.unique_id()
-            self.document_properties["base"]["datestamp"] = str(datetime.utcnow())
+            self.document_properties["base"]["datestamp"] = _utc_timestamp()
 
             for key, value in kwargs.items():
                 path = key.split(".")

--- a/src/did/document.py
+++ b/src/did/document.py
@@ -133,9 +133,21 @@ class Document:
         if os.path.exists(filepath):
             with open(filepath, "r") as f:
                 data = json.load(f)
-                # Ensure the 'base' key exists
+                # Ensure the 'base' key is a dict the constructor can stamp
+                # base.id / base.datestamp onto. base.schema.json stores 'base'
+                # as a LIST of field descriptors (unlike demoA.schema.json,
+                # which has no top-level 'base'), so Document('base') /
+                # Document() used to raise "TypeError: list indices must be
+                # integers". Convert that descriptor list to a {name:
+                # default_value} defaults dict. (This is the narrow constructor
+                # fix only; the broader build-from-database_documents rework is
+                # tracked separately.)
                 if "base" not in data:
                     data["base"] = {}
+                elif isinstance(data["base"], list):
+                    data["base"] = Document._field_descriptors_to_defaults(
+                        data["base"]
+                    )
                 # Convert flat classname/superclasses to document_class format
                 data = Document._normalize_to_document_class(data)
                 return data
@@ -155,6 +167,20 @@ class Document:
         raise FileNotFoundError(
             f"Could not find definition for {json_file_location_string}"
         )
+
+    @staticmethod
+    def _field_descriptors_to_defaults(descriptors):
+        """Convert a schema field-descriptor list to a {name: default_value} dict.
+
+        Each descriptor is a dict with at least a 'name' and (usually) a
+        'default_value'. Used to turn base.schema.json's 'base' list into a
+        blank base group the constructor can stamp id/datestamp onto.
+        """
+        defaults = {}
+        for field in descriptors:
+            if isinstance(field, dict) and "name" in field:
+                defaults[field["name"]] = field.get("default_value", "")
+        return defaults
 
     @staticmethod
     def _normalize_to_document_class(data):

--- a/src/did/implementations/binarydoc_matfid.py
+++ b/src/did/implementations/binarydoc_matfid.py
@@ -2,7 +2,14 @@ from ..binarydoc import BinaryDoc
 from ..file import Fileobj
 
 
-class BinaryDocMatfid(BinaryDoc, Fileobj):
+class BinaryDocMatfid(Fileobj, BinaryDoc):
+    # NOTE: base order is (Fileobj, BinaryDoc). Previously it was
+    # (BinaryDoc, Fileobj): BinaryDoc.__init__ is a bare ``pass`` that never
+    # calls super().__init__(), so Fileobj.__init__ never ran (fullpathfilename
+    # / permission / fid were unset) and every ``super().f*`` call resolved to
+    # BinaryDoc's abstract no-op stub, so fopen() silently returned None without
+    # opening anything. With Fileobj first in the MRO, __init__ initializes the
+    # file object and the f* methods delegate to real implementations.
     def __init__(self, key="", doc_unique_id="", **kwargs):
         super().__init__(**kwargs)
         self.key = key
@@ -31,11 +38,22 @@ class BinaryDocMatfid(BinaryDoc, Fileobj):
         return super().feof()
 
     def fwrite(self, data, precision=None, skip=0):
-        # The precision and skip parameters would need to be handled
-        # using Python's struct module for a full implementation.
+        # precision/skip (MATLAB struct-format writes) are not implemented yet.
+        # Fail loudly rather than silently ignoring them and writing raw bytes.
+        if precision is not None or skip:
+            raise NotImplementedError(
+                "BinaryDocMatfid.fwrite does not yet support precision/skip; "
+                "only raw byte writes are supported."
+            )
         return super().fwrite(data)
 
     def fread(self, count=-1, precision=None, skip=0):
-        # The precision and skip parameters would need to be handled
-        # using Python's struct module for a full implementation.
+        # precision/skip (MATLAB struct-format reads) are not implemented yet.
+        # Raise rather than returning None so a caller can't mistake an
+        # unimplemented typed read for an empty file.
+        if precision is not None or skip:
+            raise NotImplementedError(
+                "BinaryDocMatfid.fread does not yet support precision/skip; "
+                "only raw byte reads are supported."
+            )
         return super().fread(count)

--- a/src/did/implementations/doc2sql.py
+++ b/src/did/implementations/doc2sql.py
@@ -49,6 +49,14 @@ def _get_superclass_str(doc_props):
     MATLAB produces comma-space separated, sorted unique superclass names.
     For MATLAB-style definitions like "$PATH/base.json", strip path and extension.
     For DID-python style ["base", "demoA"], use directly.
+
+    Schema-v2 (DID-schema V_delta / V_epsilon) names a superclass directly with a
+    bare ``{"class_name": ...}`` object. Read ``class_name`` first but UNION in the
+    ``definition``-derived name rather than short-circuiting, so a mixed-shape entry
+    never silently narrows the superclass set. This mirrors the reference contract
+    in ndi-cloud-node ``api/src/dal/class_lineage.ts`` (``computeClassLineage``) and
+    NDI-python ``ndi.document.doc_superclass``, keeping the SQL ``meta.superclass``
+    column (and both isa paths that read it) consistent across all three stacks.
     """
     # DID-python schema format: top-level 'superclasses' list of strings
     if "superclasses" in doc_props and isinstance(
@@ -65,12 +73,16 @@ def _get_superclass_str(doc_props):
         for sc in superclasses:
             if isinstance(sc, str):
                 names.append(sc)
-            elif isinstance(sc, dict) and "definition" in sc:
-                # MATLAB-style: extract name from definition path
-                defn = sc["definition"]
-                name = re.sub(r".+/", "", defn)
-                name = re.sub(r"\..+$", "", name)
-                names.append(name)
+            elif isinstance(sc, dict):
+                # class_name-first, UNION with the definition-derived name.
+                if sc.get("class_name"):
+                    names.append(sc["class_name"])
+                if sc.get("definition"):
+                    # MATLAB-style: extract name from definition path
+                    defn = sc["definition"]
+                    name = re.sub(r".+/", "", defn)
+                    name = re.sub(r"\..+$", "", name)
+                    names.append(name)
         names = sorted(set(names))
         return ", ".join(names)
 
@@ -82,11 +94,15 @@ def _get_superclass_str(doc_props):
     if isinstance(superclasses, list):
         names = []
         for sc in superclasses:
-            if isinstance(sc, dict) and "definition" in sc:
-                defn = sc["definition"]
-                name = re.sub(r".+/", "", defn)
-                name = re.sub(r"\..+$", "", name)
-                names.append(name)
+            if isinstance(sc, dict):
+                # class_name-first, UNION with the definition-derived name.
+                if sc.get("class_name"):
+                    names.append(sc["class_name"])
+                if sc.get("definition"):
+                    defn = sc["definition"]
+                    name = re.sub(r".+/", "", defn)
+                    name = re.sub(r"\..+$", "", name)
+                    names.append(name)
             elif isinstance(sc, str):
                 names.append(sc)
         names = sorted(set(names))

--- a/src/did/implementations/doc2sql.py
+++ b/src/did/implementations/doc2sql.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 
@@ -131,15 +132,39 @@ def _serialize_depends_on(doc_props):
 
 
 def _flatten_dict(d, prefix=""):
-    """Flatten a nested dict using ___ separator for nested keys (matching MATLAB's getMetaTableFrom)."""
+    """Flatten a nested dict using ___ separator for nested keys.
+
+    Matches DID-matlab getMetaTableFrom/recurseFields:
+
+    * nested dicts recurse with a ``___`` separator;
+    * a list of dicts (a struct array) expands into one column per element,
+      each element's flattened column suffixed ``_<1-based idx>`` — but ONLY
+      when the list has more than one element (a single-element list is
+      unsuffixed, mirroring doc2sql.m's ``numElements > 1`` rule);
+    * any residual scalar/mixed list is JSON-encoded (not ``str()``-repr'd) so
+      the stored value is valid JSON parseable by MATLAB/JS consumers instead
+      of a Python repr with single quotes.
+
+    Previously every list was ``str(value)``'d into one column, so per-element
+    fields were unsearchable and the stored string disagreed with what
+    DID-matlab writes for the same document.
+    """
     items = []
     for key, value in d.items():
         col_name = f"{prefix}___{key}" if prefix else key
         if isinstance(value, dict):
             items.extend(_flatten_dict(value, col_name))
         elif isinstance(value, list):
-            # Convert lists to string representation
-            items.append((col_name, str(value)))
+            if value and all(isinstance(el, dict) for el in value):
+                # Struct array: expand per element.
+                multi = len(value) > 1
+                for idx, el in enumerate(value, start=1):
+                    for sub_name, sub_val in _flatten_dict(el, col_name):
+                        name = f"{sub_name}_{idx}" if multi else sub_name
+                        items.append((name, sub_val))
+            else:
+                # Scalar / empty / mixed list: JSON-encode.
+                items.append((col_name, json.dumps(value)))
         else:
             items.append((col_name, value))
     return items

--- a/src/did/implementations/sqlitedb.py
+++ b/src/did/implementations/sqlitedb.py
@@ -502,7 +502,17 @@ class SQLiteDB(Database):
             return f"fields.field_name = '{field}' AND LOWER(doc_data.value) = LOWER('{_sql_escape(param1)}')"
 
         elif op_lower == "contains_string":
-            return f"fields.field_name = '{field}' AND doc_data.value LIKE '%{_sql_escape(param1)}%'"
+            # param1 is arbitrary user text: '%' and '_' in it must NOT act as
+            # LIKE wildcards (otherwise 'spike_sort' would also match
+            # 'spikeXsort'), which would diverge from the brute-force
+            # ``param1 in value`` path. Escape the LIKE wildcards, add an ESCAPE
+            # clause, and SQL-escape the surrounding literal. The bracketing
+            # '%' are the real "contains" wildcards and stay unescaped.
+            param_like = _sql_escape(_sql_like_escape(param1))
+            return (
+                f"fields.field_name = '{field}' AND doc_data.value "
+                f"LIKE '%{param_like}%' ESCAPE '{_LIKE_ESCAPE_CHAR}'"
+            )
 
         elif op_lower == "regexp":
             return f"fields.field_name = '{field}' AND regexp('{_sql_escape(param1)}', doc_data.value) IS NOT NULL"
@@ -553,15 +563,30 @@ class SQLiteDB(Database):
             )
 
         elif op_lower == "depends_on":
-            # depends_on: search meta.depends_on using LIKE '%name,value;%'
-            name = _sql_escape(param1)
-            value = _sql_escape(param2)
-            if name == "*":
-                return f"fields.field_name = 'meta.depends_on' AND doc_data.value LIKE '%,{value};%'"
-            return f"fields.field_name = 'meta.depends_on' AND doc_data.value LIKE '%{name},{value};%'"
+            # depends_on: search meta.depends_on using LIKE '%name,value;%'.
+            # NOTE: this branch is currently unreachable — Query._resolve_single
+            # rewrites every 'depends_on' into 'hasanysubfield_exact_string'
+            # before it reaches here, so depends_on always brute-forces. The
+            # LIKE-wildcard escaping below is applied defensively so that if the
+            # resolution is ever changed to let this branch run, '_'/'%' in the
+            # dependency name/value can't silently act as wildcards. The ','/';'
+            # delimiters and the bracketing '%' are the real pattern structure
+            # and stay unescaped.
+            name = _sql_escape(_sql_like_escape(param1))
+            value = _sql_escape(_sql_like_escape(param2))
+            if param1 == "*":
+                return (
+                    "fields.field_name = 'meta.depends_on' AND doc_data.value "
+                    f"LIKE '%,{value};%' ESCAPE '{_LIKE_ESCAPE_CHAR}'"
+                )
+            return (
+                "fields.field_name = 'meta.depends_on' AND doc_data.value "
+                f"LIKE '%{name},{value};%' ESCAPE '{_LIKE_ESCAPE_CHAR}'"
+            )
 
         elif op_lower == "hasanysubfield_exact_string":
-            # Used by resolved depends_on - fall back to brute force
+            # unreachable — see Query._resolve_single (resolved depends_on);
+            # falls back to brute force
             return None
 
         elif op_lower == "hasanysubfield_contains_string":

--- a/src/did/implementations/sqlitedb.py
+++ b/src/did/implementations/sqlitedb.py
@@ -21,6 +21,29 @@ def _sql_escape(value):
     return str(value).replace("'", "''")
 
 
+# Escape character used in LIKE patterns (see _sql_like_escape / ESCAPE clauses).
+_LIKE_ESCAPE_CHAR = "\\"
+
+
+def _sql_like_escape(value):
+    """Escape LIKE wildcards in a literal operand of a LIKE pattern.
+
+    '%' and '_' are LIKE wildcards; without escaping, a field name containing
+    '_' would match any single character (e.g. 'a_b' would also match 'axb'),
+    producing false-positive matches. Callers that embed the result inside a
+    LIKE pattern must also append "ESCAPE '\\'" so the backslash is treated as
+    the escape character. The single-quote escaping for the surrounding SQL
+    string literal is applied on top of this by _sql_escape.
+    """
+    if value is None:
+        return ""
+    text = str(value)
+    text = text.replace(_LIKE_ESCAPE_CHAR, _LIKE_ESCAPE_CHAR * 2)
+    text = text.replace("%", _LIKE_ESCAPE_CHAR + "%")
+    text = text.replace("_", _LIKE_ESCAPE_CHAR + "_")
+    return text
+
+
 class SQLiteDB(Database):
     def __init__(self, filename):
         super().__init__(connection=filename)
@@ -413,7 +436,13 @@ class SQLiteDB(Database):
             return result
 
         # Leaf query: build SQL and execute
-        sql_clause = self._query_struct_to_sql_str(search_struct)
+        try:
+            sql_clause = self._query_struct_to_sql_str(search_struct)
+        except (ValueError, TypeError):
+            # A numeric operation (exact_number/lessthan/greaterthan/...) was
+            # given a non-numeric param1, so the float() conversion failed.
+            # Fall back to brute force rather than aborting the whole search.
+            return self._brute_force_search(search_struct, branch_id)
         if sql_clause is None:
             # Fallback to brute-force for unsupported operations
             return self._brute_force_search(search_struct, branch_id)
@@ -494,17 +523,33 @@ class SQLiteDB(Database):
             return f"fields.field_name = '{field}' AND CAST(doc_data.value AS REAL) >= {float(param1)}"
 
         elif op_lower == "hasfield":
+            # 'field' is charset-restricted above, but it may legitimately
+            # contain '_', which is a LIKE wildcard. Escape LIKE wildcards in
+            # the literal prefix and add an ESCAPE clause so a field name like
+            # 'a_b' matches 'a_b[.subfield]' exactly, not 'axb'. The trailing
+            # '.%' is a real wildcard and is left unescaped.
+            field_like = _sql_like_escape(field)
             return (
-                f"(fields.field_name = '{field}' OR fields.field_name LIKE '{field}.%')"
+                f"(fields.field_name = '{field}' "
+                f"OR fields.field_name LIKE '{field_like}.%' ESCAPE '{_LIKE_ESCAPE_CHAR}')"
             )
 
         elif op_lower == "isa":
-            # isa: match on meta.class (exact) OR meta.superclass (contains)
+            # isa: match on meta.class (exact) OR meta.superclass (contains).
+            # The meta.class branch is an exact string compare, so it only
+            # needs SQL-literal escaping. The meta.superclass branch embeds the
+            # class name inside a regexp() pattern; regex metacharacters in the
+            # class name (e.g. '.') must be regex-escaped first, otherwise a
+            # name like 'foo.bar' would also match 'fooxbar'. Anchor it as an
+            # exact list-element match between the '(^|, )' / '(,|$)' delimiters.
             classname = _sql_escape(param1)
+            classname_re = _sql_escape(
+                _re.escape("" if param1 is None else str(param1))
+            )
             return (
                 f"((fields.field_name = 'meta.class' AND doc_data.value = '{classname}') "
                 f"OR (fields.field_name = 'meta.superclass' AND "
-                f"regexp('(^|, ){classname}(,|$)', doc_data.value) IS NOT NULL))"
+                f"regexp('(^|, ){classname_re}(,|$)', doc_data.value) IS NOT NULL))"
             )
 
         elif op_lower == "depends_on":

--- a/src/did/implementations/sqlitedb.py
+++ b/src/did/implementations/sqlitedb.py
@@ -603,19 +603,32 @@ class SQLiteDB(Database):
         # and docs indexes. Branch membership is enforced by the JOIN; docs
         # not in the branch simply aren't returned and are handled by the
         # OnMissing pass below (same behaviour as before).
-        placeholders = ",".join("?" for _ in document_ids)
-        if branch_id is not None:
-            rows = self.do_run_sql_query(
-                f"SELECT d.doc_id, d.json_code FROM docs d "
-                f"JOIN branch_docs bd ON d.doc_idx = bd.doc_idx "
-                f"WHERE bd.branch_id = ? AND d.doc_id IN ({placeholders})",
-                (branch_id, *document_ids),
-            )
-        else:
-            rows = self.do_run_sql_query(
-                f"SELECT doc_id, json_code FROM docs WHERE doc_id IN ({placeholders})",
-                tuple(document_ids),
-            )
+        # Chunk the IN-list: SQLite caps host parameters per statement
+        # (SQLITE_MAX_VARIABLE_NUMBER — 999 on older builds), so a get_docs
+        # over thousands of ids (e.g. a cross-document query on a large cloud
+        # dataset) would raise "too many SQL variables". Batch under the limit
+        # and accumulate; order is restored from doc_map below.
+        _CHUNK = 900
+        rows = []
+        for _i in range(0, len(document_ids), _CHUNK):
+            chunk = document_ids[_i : _i + _CHUNK]
+            placeholders = ",".join("?" for _ in chunk)
+            if branch_id is not None:
+                rows.extend(
+                    self.do_run_sql_query(
+                        f"SELECT d.doc_id, d.json_code FROM docs d "
+                        f"JOIN branch_docs bd ON d.doc_idx = bd.doc_idx "
+                        f"WHERE bd.branch_id = ? AND d.doc_id IN ({placeholders})",
+                        (branch_id, *chunk),
+                    )
+                )
+            else:
+                rows.extend(
+                    self.do_run_sql_query(
+                        f"SELECT doc_id, json_code FROM docs WHERE doc_id IN ({placeholders})",
+                        tuple(chunk),
+                    )
+                )
 
         # Build lookup dict
         doc_map = {}

--- a/src/did/implementations/sqlitedb.py
+++ b/src/did/implementations/sqlitedb.py
@@ -341,42 +341,93 @@ class SQLiteDB(Database):
 
         return props
 
-    def _do_add_doc(self, document_obj, branch_id, **kwargs):
+    def _do_add_doc(self, document_obj, branch_id, OnDuplicate="error", **kwargs):
         import json
         import time
+        import warnings
+
+        on_dup = str(OnDuplicate).lower()
+        if on_dup not in self._ON_DUPLICATE_CHOICES:
+            raise ValueError(
+                "OnDuplicate must be one of "
+                f"{self._ON_DUPLICATE_CHOICES}; got {OnDuplicate!r}."
+            )
 
         doc_id = document_obj.id()
         cursor = self.dbid.cursor()
 
-        cursor.execute("SELECT doc_idx FROM docs WHERE doc_id = ?", (doc_id,))
-        row = cursor.fetchone()
+        # Validate branch existence BEFORE any INSERT. Previously the docs and
+        # doc_data rows were inserted first and the missing branch was only
+        # discovered by the branch_docs FOREIGN KEY check, which raised without
+        # rolling back — leaving orphan rows in the open transaction that the
+        # next successful add committed (a document belonging to no branch was
+        # then reported present). Checking first means a bad branch never
+        # inserts anything.
+        cursor.execute("SELECT 1 FROM branches WHERE branch_id = ?", (branch_id,))
+        if not cursor.fetchone():
+            raise ValueError(f"Branch '{branch_id}' does not exist.")
 
-        if row:
-            doc_idx = row["doc_idx"]
-        else:
-            json_code = json.dumps(
-                self._matlab_compatible_props(document_obj.document_properties)
-            )
-            cursor.execute(
-                "INSERT INTO docs (doc_id, json_code, timestamp) VALUES (?, ?, ?)",
-                (doc_id, json_code, time.time()),
-            )
-            doc_idx = cursor.lastrowid
-
-            # Populate fields and doc_data tables (matching MATLAB's doc2sql behavior)
-            self._populate_doc_data(cursor, doc_idx, document_obj)
+        # Snapshot the fields cache so a rollback also unwinds any field_idx
+        # entries _populate_doc_data added for fields whose INSERTs get rolled
+        # back with the transaction (otherwise the cache would point at
+        # non-existent field rows).
+        cache_before = dict(self._fields_cache)
 
         try:
+            cursor.execute("SELECT doc_idx FROM docs WHERE doc_id = ?", (doc_id,))
+            row = cursor.fetchone()
+
+            if row:
+                doc_idx = row["doc_idx"]
+            else:
+                json_code = json.dumps(
+                    self._matlab_compatible_props(document_obj.document_properties)
+                )
+                cursor.execute(
+                    "INSERT INTO docs (doc_id, json_code, timestamp) VALUES (?, ?, ?)",
+                    (doc_id, json_code, time.time()),
+                )
+                doc_idx = cursor.lastrowid
+
+                # Populate fields and doc_data tables (matching MATLAB's doc2sql behavior)
+                self._populate_doc_data(cursor, doc_idx, document_obj)
+
+            # Is this document already on this branch? If so it is a duplicate.
+            # DID-matlab's add_docs errors by default (OnDuplicate='error');
+            # the previous Python code swallowed the branch_docs duplicate with
+            # a bare ``pass``, silently keeping stale content. Honor OnDuplicate.
+            cursor.execute(
+                "SELECT 1 FROM branch_docs WHERE branch_id = ? AND doc_idx = ?",
+                (branch_id, doc_idx),
+            )
+            if cursor.fetchone():
+                if on_dup == "error":
+                    raise ValueError(
+                        f"Document '{doc_id}' is already in branch '{branch_id}'."
+                    )
+                if on_dup == "warn":
+                    warnings.warn(
+                        f"Document '{doc_id}' is already in branch '{branch_id}'; "
+                        "leaving the existing entry unchanged.",
+                        stacklevel=2,
+                    )
+                # 'ignore'/'warn': no-op (do not rewrite content). Commit so any
+                # docs/doc_data rows inserted above for a brand-new doc_id are
+                # persisted, then return.
+                self.dbid.commit()
+                return
+
             cursor.execute(
                 "INSERT INTO branch_docs (branch_id, doc_idx, timestamp) VALUES (?, ?, ?)",
                 (branch_id, doc_idx, time.time()),
             )
             self.dbid.commit()
-        except sqlite3.IntegrityError as e:
-            if "FOREIGN KEY" in str(e):
-                raise ValueError(f"Branch '{branch_id}' does not exist.")
-            # Ignore other integrity errors (duplicates)
-            pass
+        except Exception:
+            # Every failure path rolls back so no partial rows survive into the
+            # next transaction, and the fields cache is restored to match.
+            self.dbid.rollback()
+            self._fields_cache = cache_before
+            raise
 
     # --- SQL-based search (matching MATLAB's database.m) ---
 

--- a/tests/symmetry/read_artifacts/database/test_build_database.py
+++ b/tests/symmetry/read_artifacts/database/test_build_database.py
@@ -17,6 +17,25 @@ from did.util import compare_database_summary, database_summary
 from tests.symmetry.conftest import SYMMETRY_BASE
 
 
+def _missing_artifact(message):
+    """Fail when cross-language artifacts are required, otherwise skip.
+
+    These conditions used to unconditionally ``pytest.skip()``, which exits 0 —
+    so a symmetry job that produced NO cross-language artifacts (e.g. MATLAB's
+    tempdir diverged from Python's and matlabArtifacts was never written)
+    passed green having compared nothing across languages. In the symmetry.yml
+    read_artifacts step the artifacts ARE produced by an earlier step in the
+    same job (MATLAB makeArtifacts in Step 1, Python makeArtifacts in Step 2),
+    so their absence is a real failure; that step sets
+    ``DID_SYMMETRY_REQUIRE_ARTIFACTS`` and this helper fails hard. Under a plain
+    ``pytest`` run (python-package.yml, local dev) the OTHER language's
+    artifacts legitimately do not exist, so skip as before.
+    """
+    if os.environ.get("DID_SYMMETRY_REQUIRE_ARTIFACTS"):
+        pytest.fail(message)
+    pytest.skip(message)
+
+
 class TestReadBuildDatabase:
     """Read and validate DID database artifacts for cross-language symmetry testing."""
 
@@ -30,14 +49,16 @@ class TestReadBuildDatabase:
         )
 
         if not os.path.isdir(artifact_dir):
-            pytest.skip(
+            _missing_artifact(
                 f"Artifact directory from {source_type} does not exist: {artifact_dir}"
             )
 
         # Step 1: Load the saved summary
         summary_file = os.path.join(artifact_dir, "summary.json")
         if not os.path.isfile(summary_file):
-            pytest.skip(f"summary.json not found in {source_type} artifact directory.")
+            _missing_artifact(
+                f"summary.json not found in {source_type} artifact directory."
+            )
 
         with open(summary_file, "r") as f:
             saved_summary = json.load(f)
@@ -48,7 +69,7 @@ class TestReadBuildDatabase:
         # Step 2: Open the DID database and produce a live summary
         db_path = os.path.join(artifact_dir, saved_summary["dbFilename"])
         if not os.path.isfile(db_path):
-            pytest.skip(f"Database file not found: {db_path}")
+            _missing_artifact(f"Database file not found: {db_path}")
 
         db = SQLiteDB(db_path)
         live_summary = database_summary(db)
@@ -66,14 +87,14 @@ class TestReadBuildDatabase:
 
         json_branches_dir = os.path.join(artifact_dir, "jsonBranches")
         if not os.path.isdir(json_branches_dir):
-            pytest.skip(f"jsonBranches directory not found in {source_type}")
+            _missing_artifact(f"jsonBranches directory not found in {source_type}")
 
         for branch_name in branch_names:
             branch_json_file = os.path.join(
                 json_branches_dir, f"branch_{branch_name}.json"
             )
             if not os.path.isfile(branch_json_file):
-                pytest.skip(
+                _missing_artifact(
                     f"Branch JSON file missing for {branch_name} in {source_type}"
                 )
 

--- a/tests/test_add_docs_atomicity.py
+++ b/tests/test_add_docs_atomicity.py
@@ -13,8 +13,8 @@ Two closely-coupled correctness fixes that both restructure ``_do_add_doc``:
 """
 
 import os
-import warnings
 import unittest
+import warnings
 
 from did.document import Document
 from did.implementations.sqlitedb import SQLiteDB

--- a/tests/test_add_docs_atomicity.py
+++ b/tests/test_add_docs_atomicity.py
@@ -1,0 +1,102 @@
+"""Atomicity and OnDuplicate tests for ``SQLiteDB._do_add_doc``.
+
+Two closely-coupled correctness fixes that both restructure ``_do_add_doc``:
+
+* A failed add to a nonexistent branch used to insert the docs/doc_data rows
+  BEFORE the branch_docs FOREIGN KEY check failed, and never rolled back — so
+  the orphan rows sat in the open transaction and were committed by the next
+  successful add (a document belonging to no branch was reported present).
+* Re-adding a document already on a branch silently swallowed the duplicate
+  (``except sqlite3.IntegrityError: pass``), keeping stale content, where
+  DID-matlab errors by default. ``OnDuplicate`` in {error(default),warn,ignore}
+  now governs that path.
+"""
+
+import os
+import warnings
+import unittest
+
+from did.document import Document
+from did.implementations.sqlitedb import SQLiteDB
+
+
+def _make_doc(idhex, value=1):
+    return Document(
+        {
+            "base": {"id": idhex, "datestamp": "2020-01-01"},
+            "document_class": {"class_name": "thing"},
+            "demoA": {"value": value},
+        }
+    )
+
+
+class TestAddDocsAtomicity(unittest.TestCase):
+    DB_FILENAME = "test_add_docs_atomicity.sqlite"
+
+    def setUp(self):
+        if os.path.exists(self.DB_FILENAME):
+            os.remove(self.DB_FILENAME)
+        self.db = SQLiteDB(self.DB_FILENAME)
+        self.db.add_branch("a")
+
+    def tearDown(self):
+        self.db._close_db()
+        if os.path.exists(self.DB_FILENAME):
+            os.remove(self.DB_FILENAME)
+
+    def test_failed_add_to_missing_branch_leaves_no_orphan(self):
+        z = _make_doc("a" * 32)
+
+        # Add to a nonexistent branch: must raise ...
+        with self.assertRaises(ValueError):
+            self.db.add_docs([z], branch_id="nonexistent")
+
+        # ... and a SUBSEQUENT SUCCESSFUL add must commit. Without this second
+        # add the orphan row would merely be uncommitted and the assertion below
+        # would pass spuriously; the second commit is what would have flushed a
+        # leaked orphan to disk under the old code.
+        other = _make_doc("b" * 32)
+        self.db.add_docs([other], branch_id="a")
+
+        all_ids = self.db.all_doc_ids()
+        self.assertNotIn(z.id(), all_ids)
+        self.assertIn(other.id(), all_ids)
+
+    def test_duplicate_in_branch_raises_by_default(self):
+        d = _make_doc("c" * 32)
+        self.db.add_docs([d], branch_id="a")
+        with self.assertRaises(ValueError):
+            self.db.add_docs([d], branch_id="a")
+
+    def test_duplicate_onduplicate_ignore_does_not_raise(self):
+        d = _make_doc("d" * 32)
+        self.db.add_docs([d], branch_id="a")
+        # Must not raise and must leave exactly one entry.
+        self.db.add_docs([d], branch_id="a", OnDuplicate="ignore")
+        self.assertEqual(self.db.all_doc_ids().count(d.id()), 1)
+
+    def test_duplicate_onduplicate_warn_warns(self):
+        d = _make_doc("e" * 32)
+        self.db.add_docs([d], branch_id="a")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # ensure a warning is actually raised
+            with self.assertRaises(UserWarning):
+                self.db.add_docs([d], branch_id="a", OnDuplicate="warn")
+
+    def test_rejects_invalid_onduplicate_value(self):
+        d = _make_doc("f" * 32)
+        with self.assertRaises(ValueError):
+            self.db.add_docs([d], branch_id="a", OnDuplicate="bogus")
+
+    def test_adding_existing_doc_to_new_branch_is_not_a_duplicate(self):
+        # A doc already in docs (from branch 'a') added to a DIFFERENT branch is
+        # a legitimate cross-branch add, not a duplicate, and must not raise.
+        d = _make_doc("1" * 32)
+        self.db.add_docs([d], branch_id="a")
+        self.db.add_branch("b", parent_branch_id="")
+        self.db.add_docs([d], branch_id="b")
+        self.assertIn(d.id(), self.db.get_doc_ids("b"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_binarydoc_matfid.py
+++ b/tests/test_binarydoc_matfid.py
@@ -1,0 +1,53 @@
+"""Tests for BinaryDocMatfid Fileobj initialization and fail-loud behavior.
+
+BinaryDocMatfid used to declare its bases as (BinaryDoc, Fileobj). BinaryDoc's
+__init__ is a bare ``pass`` that never calls super().__init__(), so
+Fileobj.__init__ never ran and every ``super().f*`` call resolved to BinaryDoc's
+abstract no-op stub — fopen() returned None without opening anything. Bases are
+now (Fileobj, BinaryDoc), so the Fileobj half is initialized and the file
+operations delegate to real implementations.
+"""
+
+import os
+import tempfile
+import unittest
+
+from did.implementations.binarydoc_matfid import BinaryDocMatfid
+
+
+class TestBinaryDocMatfid(unittest.TestCase):
+    def test_init_sets_fileobj_attributes(self):
+        b = BinaryDocMatfid()
+        # Fileobj.__init__ must have run.
+        self.assertTrue(hasattr(b, "fullpathfilename"))
+        self.assertTrue(hasattr(b, "permission"))
+        self.assertEqual(b.machineformat, "l")
+        self.assertIsNone(b.fid)
+
+    def test_fopen_actually_opens_a_file(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            with open(path, "wb") as f:
+                f.write(b"hello")
+            b = BinaryDocMatfid(fullpathfilename=path, permission="r")
+            b.fopen()
+            self.assertIsNotNone(b.fid)  # a real file handle, not None
+            self.assertEqual(b.fread(5), b"hello")
+            b.fclose()
+        finally:
+            os.remove(path)
+
+    def test_fread_with_precision_raises_notimplemented(self):
+        b = BinaryDocMatfid()
+        with self.assertRaises(NotImplementedError):
+            b.fread(10, precision="double")
+
+    def test_fwrite_with_skip_raises_notimplemented(self):
+        b = BinaryDocMatfid()
+        with self.assertRaises(NotImplementedError):
+            b.fwrite(b"x", skip=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doc2sql_flatten.py
+++ b/tests/test_doc2sql_flatten.py
@@ -30,9 +30,7 @@ class TestFlattenStructArray:
         assert cols == {"channel___name": "ch1"}
 
     def test_nested_dict_within_element(self):
-        items = _flatten_dict(
-            {"channel": [{"loc": {"x": 1}}, {"loc": {"x": 2}}]}
-        )
+        items = _flatten_dict({"channel": [{"loc": {"x": 1}}, {"loc": {"x": 2}}]})
         cols = _cols(items)
         assert cols["channel___loc___x_1"] == 1
         assert cols["channel___loc___x_2"] == 2

--- a/tests/test_doc2sql_flatten.py
+++ b/tests/test_doc2sql_flatten.py
@@ -6,8 +6,8 @@ str()-repr'd any list into a single column, so per-element fields were
 unsearchable and the stored string disagreed with DID-matlab.
 """
 
-from did.implementations.doc2sql import _flatten_dict, doc_to_sql
 from did.document import Document
+from did.implementations.doc2sql import _flatten_dict, doc_to_sql
 
 
 def _cols(items):

--- a/tests/test_doc2sql_flatten.py
+++ b/tests/test_doc2sql_flatten.py
@@ -1,0 +1,58 @@
+"""Tests for _flatten_dict list-of-dict (struct-array) expansion.
+
+DID-matlab getMetaTableFrom expands a struct array into one column per element,
+suffixed '_<1-based idx>' only when numElements > 1. The Python port previously
+str()-repr'd any list into a single column, so per-element fields were
+unsearchable and the stored string disagreed with DID-matlab.
+"""
+
+from did.implementations.doc2sql import _flatten_dict, doc_to_sql
+from did.document import Document
+
+
+def _cols(items):
+    return dict(items)
+
+
+class TestFlattenStructArray:
+    def test_multi_element_list_is_suffixed(self):
+        items = _flatten_dict({"channel": [{"name": "ch1"}, {"name": "ch2"}]})
+        cols = _cols(items)
+        assert cols["channel___name_1"] == "ch1"
+        assert cols["channel___name_2"] == "ch2"
+        # No unsuffixed collision column.
+        assert "channel___name" not in cols
+
+    def test_single_element_list_is_unsuffixed(self):
+        # numElements == 1 -> no '_1' suffix (the rule easiest to get wrong).
+        items = _flatten_dict({"channel": [{"name": "ch1"}]})
+        cols = _cols(items)
+        assert cols == {"channel___name": "ch1"}
+
+    def test_nested_dict_within_element(self):
+        items = _flatten_dict(
+            {"channel": [{"loc": {"x": 1}}, {"loc": {"x": 2}}]}
+        )
+        cols = _cols(items)
+        assert cols["channel___loc___x_1"] == 1
+        assert cols["channel___loc___x_2"] == 2
+
+    def test_scalar_list_is_json_not_repr(self):
+        # A residual scalar list must be JSON (double quotes), not a Python repr.
+        items = _flatten_dict({"tags": ["a", "b"]})
+        cols = _cols(items)
+        assert cols["tags"] == '["a", "b"]'
+
+    def test_doc_to_sql_expands_group_struct_array(self):
+        doc = Document(
+            {
+                "base": {"id": "a" * 32, "datestamp": "2020-01-01"},
+                "document_class": {"class_name": "thing"},
+                "element": {"channel": [{"name": "ch1"}, {"name": "ch2"}]},
+            }
+        )
+        tables = doc_to_sql(doc)
+        element = next(t for t in tables if t["name"] == "element")
+        names = {c["name"]: c["value"] for c in element["columns"]}
+        assert names["channel___name_1"] == "ch1"
+        assert names["channel___name_2"] == "ch2"

--- a/tests/test_doc2sql_superclass.py
+++ b/tests/test_doc2sql_superclass.py
@@ -43,3 +43,85 @@ class TestGetSuperclassStrBareDict:
     def test_no_superclasses(self):
         doc_props = {}
         assert _get_superclass_str(doc_props) == ""
+
+
+class TestGetSuperclassStrClassName:
+    """Schema-v2 (V_delta / V_epsilon) names superclasses with bare
+    ``{"class_name": ...}`` objects. ``_get_superclass_str`` must read
+    ``class_name`` first but UNION in any ``definition``-derived name (never
+    short-circuit), so ``meta.superclass`` — and both isa paths that read it —
+    stay consistent with ndi-cloud-node ``class_lineage.ts`` and NDI-python
+    ``ndi.document.doc_superclass``. On today's corpus every entry is
+    ``{definition}`` (class_name count = 0), so this branch is purely additive.
+    """
+
+    # --- top-level 'superclasses' branch (DID-python schema shape) ---
+    def test_top_level_class_name_only(self):
+        assert _get_superclass_str({"superclasses": [{"class_name": "base"}]}) == "base"
+
+    def test_top_level_bare_dict_class_name(self):
+        assert _get_superclass_str({"superclasses": {"class_name": "base"}}) == "base"
+
+    def test_top_level_class_name_list(self):
+        doc_props = {"superclasses": [{"class_name": "base"}, {"class_name": "demoA"}]}
+        assert _get_superclass_str(doc_props) == "base, demoA"
+
+    def test_top_level_union_no_shortcircuit(self):
+        # CONFORMANCE PIN: class_name AND a *differing* definition -> BOTH names.
+        # A short-circuit accessor would drop "base" and return "custom_marker".
+        sc = {"class_name": "custom_marker", "definition": "$NDIDOCUMENTPATH/base.json"}
+        assert _get_superclass_str({"superclasses": [sc]}) == "base, custom_marker"
+
+    def test_top_level_mixed_agreeing_dedup(self):
+        sc = {"class_name": "base", "definition": "$NDIDOCUMENTPATH/base.json"}
+        assert _get_superclass_str({"superclasses": [sc]}) == "base"
+
+    def test_top_level_empty_class_name_falls_back(self):
+        sc = {"class_name": "", "definition": "$NDIDOCUMENTPATH/base.json"}
+        assert _get_superclass_str({"superclasses": [sc]}) == "base"
+
+    # --- document_class.superclasses branch (NDI / MATLAB shape) ---
+    def test_document_class_class_name_only(self):
+        doc = {"document_class": {"superclasses": [{"class_name": "base"}]}}
+        assert _get_superclass_str(doc) == "base"
+
+    def test_document_class_bare_dict_class_name(self):
+        doc = {"document_class": {"superclasses": {"class_name": "base"}}}
+        assert _get_superclass_str(doc) == "base"
+
+    def test_document_class_union_no_shortcircuit(self):
+        doc = {
+            "document_class": {
+                "superclasses": [
+                    {
+                        "class_name": "custom_marker",
+                        "definition": "$NDIDOCUMENTPATH/base.json",
+                    }
+                ]
+            }
+        }
+        assert _get_superclass_str(doc) == "base, custom_marker"
+
+    def test_document_class_mixed_shapes(self):
+        # A document may mix a v2 entry and a legacy entry in one list.
+        doc = {
+            "document_class": {
+                "superclasses": [
+                    {"class_name": "element"},
+                    {"definition": "$NDIDOCUMENTPATH/base.json"},
+                ]
+            }
+        }
+        assert _get_superclass_str(doc) == "base, element"
+
+    def test_document_class_v1_definition_unchanged(self):
+        # Regression guard: the entire current corpus is definition-only.
+        doc = {
+            "document_class": {
+                "superclasses": [
+                    {"definition": "$NDIDOCUMENTPATH/element.json"},
+                    {"definition": "$NDIDOCUMENTPATH/base.json"},
+                ]
+            }
+        }
+        assert _get_superclass_str(doc) == "base, element"

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+import re
+from datetime import datetime, timezone
 from did.document import Document
 
 
@@ -44,6 +46,22 @@ class TestDocument(unittest.TestCase):
             "updated_value",
             "Failed to update an existing dependency value.",
         )
+
+    def test_datestamp_is_iso8601_utc(self):
+        # base.datestamp must be ISO-8601 millis + 'Z' (not the old
+        # space-separated tz-less str(datetime.utcnow()) form).
+        doc = Document("demoA")
+        ts = doc.document_properties["base"]["datestamp"]
+
+        self.assertRegex(
+            ts, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$"
+        )
+        # The actual bug: the string must be an unambiguous UTC instant. Parsing
+        # it must yield a timezone-aware datetime within a few seconds of now.
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        self.assertIsNotNone(parsed.tzinfo)
+        now = datetime.now(timezone.utc)
+        self.assertLess(abs((now - parsed).total_seconds()), 5)
 
     def test_file_management(self):
         # Create a document of type 'demoFile', which is defined to handle files

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-import re
 from datetime import datetime, timezone
 from did.document import Document
 
@@ -62,9 +61,7 @@ class TestDocument(unittest.TestCase):
         doc = Document("demoA")
         ts = doc.document_properties["base"]["datestamp"]
 
-        self.assertRegex(
-            ts, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$"
-        )
+        self.assertRegex(ts, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
         # The actual bug: the string must be an unambiguous UTC instant. Parsing
         # it must yield a timezone-aware datetime within a few seconds of now.
         parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -47,6 +47,15 @@ class TestDocument(unittest.TestCase):
             "Failed to update an existing dependency value.",
         )
 
+    def test_default_document_constructs(self):
+        # Document() (default type 'base') and Document('base') used to raise
+        # "TypeError: list indices must be integers" because base.schema.json
+        # stores 'base' as a list of field descriptors. Both must now construct
+        # and produce a non-empty id.
+        for doc in (Document(), Document("base")):
+            self.assertIsInstance(doc.id(), str)
+            self.assertTrue(doc.id())
+
     def test_datestamp_is_iso8601_utc(self):
         # base.datestamp must be ISO-8601 millis + 'Z' (not the old
         # space-separated tz-less str(datetime.utcnow()) form).

--- a/tests/test_invalid_modification.py
+++ b/tests/test_invalid_modification.py
@@ -28,13 +28,20 @@ class TestInvalidModification(unittest.TestCase):
         if os.path.exists(self.db_path):
             os.remove(self.db_path)
 
-    def test_add_doc_twice(self):
-        # Adding the same document twice should not raise an error
+    def test_add_doc_twice_raises_by_default(self):
+        # DID-matlab parity: re-adding a document already on the branch errors
+        # by default (OnDuplicate='error'), rather than silently keeping the
+        # existing content. Under OnDuplicate='ignore' it is a no-op.
         doc = self.docs[0]
-        try:
+        with self.assertRaises(ValueError):
             self.db._do_add_doc(doc, "a")
+
+        # 'ignore' must not raise and must leave the document present.
+        try:
+            self.db._do_add_doc(doc, "a", OnDuplicate="ignore")
         except Exception as e:
-            self.fail(f"Adding the same document twice raised an exception: {e}")
+            self.fail(f"Adding a duplicate with OnDuplicate='ignore' raised: {e}")
+        self.assertIsNotNone(self.db.get_docs(doc.id(), OnMissing="ignore"))
 
     def test_add_doc_to_nonexistent_branch(self):
         doc = self.docs[0]

--- a/tests/test_isa_parity.py
+++ b/tests/test_isa_parity.py
@@ -15,6 +15,8 @@ meta.superclass); this test pins both paths to the same, correct answer.
 import os
 import unittest
 
+import pytest
+
 from did.document import Document
 from did.implementations.sqlitedb import SQLiteDB
 from did.query import Query
@@ -252,6 +254,105 @@ class TestVEpsilonDiamondIsa(unittest.TestCase):
             self.assertEqual(
                 self._sql(c), self._brute(c), f"isa({c}) SQL vs brute-force mismatch"
             )
+
+
+class TestDirectOnlySuperclassIsa:
+    """DIRECT-ONLY (unflattened) diamond: leaf carries only its immediate
+    parent, the way a real producer stamps a class file (DID-schema class
+    files declare direct parents only; NDI-python's read_blank_definition does
+    not flatten). The existing V_epsilon fixture pre-flattens its ancestor list
+    ('scalar_observation','scalar_mass','base'), so it passes by construction
+    and cannot catch the direct-only reality it claims to protect.
+
+    Hierarchy (synthetic, no DID-schema dependency): root <- mid <- leaf, where
+    leaf.superclasses == ['mid'] ONLY.
+
+    * A leaf isa its DIRECT parent 'mid' -- works today, pinned green below.
+    * A leaf isa its GRANDPARENT 'root' -- SHOULD hold, but isa currently
+      resolves only the direct meta.superclass column and does NOT walk the
+      hierarchy transitively, so it does not. Pinned as a strict-xfail so the
+      gap is visible and CI flips to XPASS->red the moment isa becomes
+      transitive (or the fixture is accidentally flattened, the exact GATE the
+      audit calls for). Transitive isa / all_ancestors resolution is deferred
+      to the schema-migration work.
+    """
+
+    DB = "test_isa_direct_only.sqlite"
+
+    @staticmethod
+    def _v2doc(class_name, superclasses):
+        return Document(
+            {
+                "document_class": {
+                    "definition": f"$NDIDOCUMENTPATH/{class_name}.json",
+                    "class_name": class_name,
+                    "class_version": 1,
+                    "property_list_name": class_name,
+                    "superclasses": [{"class_name": s} for s in superclasses],
+                },
+                "base": {
+                    "id": f"id_{class_name}",
+                    "name": class_name,
+                    "datestamp": "2026-07-01T00:00:00",
+                },
+            }
+        )
+
+    @classmethod
+    def setup_class(cls):
+        if os.path.exists(cls.DB):
+            os.remove(cls.DB)
+        cls.db = SQLiteDB(cls.DB)
+        cls.db.add_branch("a")
+        # DIRECT-ONLY: leaf lists 'mid' only, NOT the flattened ['mid','root'].
+        specs = [
+            ("root", []),
+            ("mid", ["root"]),
+            ("leaf", ["mid"]),
+        ]
+        cls.by_class = {}
+        cls.docs = []
+        for class_name, supers in specs:
+            d = cls._v2doc(class_name, supers)
+            cls.by_class[class_name] = d
+            cls.docs.append(d)
+            cls.db._do_add_doc(d, "a")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db._close_db()
+        if os.path.exists(cls.DB):
+            os.remove(cls.DB)
+
+    def _sql(self, class_name):
+        return sorted(self.db.search(Query("", "isa", class_name), branch_id="a"))
+
+    def _brute(self, class_name):
+        ss = Query("", "isa", class_name).to_search_structure()
+        return sorted(
+            d.id() for d in self.docs if field_search(d.document_properties, ss)
+        )
+
+    def test_leaf_isa_direct_parent(self):
+        # 'mid' is the leaf's direct superclass: both paths must match today.
+        leaf = "id_leaf"
+        assert leaf in self._sql("mid")
+        assert leaf in self._brute("mid")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "isa is not transitive: a direct-only leaf (superclasses=['mid']) "
+            "does not match isa('root'). Transitive/all-ancestors resolution is "
+            "deferred to schema-migration work. Strict xfail: if this XPASSes "
+            "the fixture is flattening ancestors and must be re-examined."
+        ),
+    )
+    def test_leaf_isa_transitive_grandparent(self):
+        # root is the leaf's GRANDPARENT via mid, not a direct superclass.
+        leaf = "id_leaf"
+        assert leaf in self._sql("root")
+        assert leaf in self._brute("root")
 
 
 if __name__ == "__main__":

--- a/tests/test_isa_parity.py
+++ b/tests/test_isa_parity.py
@@ -152,5 +152,107 @@ class TestSqlFieldNameValidation(unittest.TestCase):
         self.assertEqual(result, ["id_probe"])
 
 
+class TestVEpsilonDiamondIsa(unittest.TestCase):
+    """V_epsilon's observation tier is the first MULTIPLE-INHERITANCE (diamond)
+    hierarchy: ``body_weight_observation`` isa ``scalar_observation`` AND
+    ``scalar_mass``, both reaching ``base``. A produced V_epsilon document
+    carries its FLATTENED ancestor list as bare ``{class_name}`` entries. Both
+    isa paths -- the SQL ``meta.superclass`` column (populated by
+    ``doc2sql._get_superclass_str``) and the brute-force ``field_search`` -- must
+    resolve every ancestor, reached via either parent, with no spurious match.
+    """
+
+    DB = "test_isa_v_epsilon_diamond.sqlite"
+
+    @staticmethod
+    def _v2doc(class_name, superclasses):
+        # V_epsilon shape: superclasses named by bare {class_name} (not {definition}).
+        return Document(
+            {
+                "document_class": {
+                    "definition": f"$NDIDOCUMENTPATH/{class_name}.json",
+                    "class_name": class_name,
+                    "class_version": 1,
+                    "property_list_name": class_name,
+                    "superclasses": [{"class_name": s} for s in superclasses],
+                },
+                "base": {
+                    "id": f"id_{class_name}",
+                    "name": class_name,
+                    "datestamp": "2026-06-24T00:00:00",
+                },
+            }
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        if os.path.exists(cls.DB):
+            os.remove(cls.DB)
+        cls.db = SQLiteDB(cls.DB)
+        cls.db.add_branch("a")
+        # The diamond leaf carries its FLATTENED ancestor list, exactly as a real
+        # producer stamps it (both parents + the shared root).
+        specs = [
+            ("base", []),
+            ("scalar_observation", ["base"]),
+            ("scalar_mass", ["base"]),
+            ("body_weight_observation", ["scalar_observation", "scalar_mass", "base"]),
+        ]
+        cls.by_class = {}
+        cls.docs = []
+        for class_name, supers in specs:
+            d = cls._v2doc(class_name, supers)
+            cls.by_class[class_name] = d
+            cls.docs.append(d)
+            cls.db._do_add_doc(d, "a")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db._close_db()
+        if os.path.exists(cls.DB):
+            os.remove(cls.DB)
+
+    def _sql(self, class_name):
+        return sorted(self.db.search(Query("", "isa", class_name), branch_id="a"))
+
+    def _brute(self, class_name):
+        ss = Query("", "isa", class_name).to_search_structure()
+        return sorted(
+            d.id() for d in self.docs if field_search(d.document_properties, ss)
+        )
+
+    def _expect(self, *class_names):
+        return sorted(self.by_class[c].id() for c in class_names)
+
+    def test_diamond_leaf_isa_both_parents_and_shared_ancestor(self):
+        leaf = "id_body_weight_observation"
+        for ancestor in ("scalar_observation", "scalar_mass", "base"):
+            self.assertIn(
+                leaf, self._sql(ancestor), f"SQL: leaf must be isa({ancestor})"
+            )
+            self.assertIn(leaf, self._brute(ancestor), f"brute: leaf isa({ancestor})")
+
+    def test_base_matches_whole_diamond(self):
+        # base is the root: every class in the diamond is isa(base).
+        self.assertEqual(
+            self._sql("base"),
+            self._expect(
+                "base", "scalar_observation", "scalar_mass", "body_weight_observation"
+            ),
+        )
+
+    def test_diamond_sql_and_brute_agree(self):
+        for c in (
+            "body_weight_observation",
+            "scalar_observation",
+            "scalar_mass",
+            "base",
+            "nonexistent",
+        ):
+            self.assertEqual(
+                self._sql(c), self._brute(c), f"isa({c}) SQL vs brute-force mismatch"
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_query_correctness.py
+++ b/tests/test_query_correctness.py
@@ -16,8 +16,8 @@ import os
 import unittest
 
 from did.document import Document
-from did.query import Query
 from did.implementations.sqlitedb import SQLiteDB
+from did.query import Query
 
 
 def _make_doc(idhex, *, fields=None, class_name=None, superclasses=None):

--- a/tests/test_query_correctness.py
+++ b/tests/test_query_correctness.py
@@ -108,6 +108,49 @@ class TestQueryCorrectness(unittest.TestCase):
 
         self.assertEqual(ids, [])
 
+    # --- contains_string: '_'/'%' must not behave as LIKE wildcards -----------
+
+    def test_contains_string_underscore_is_not_a_wildcard(self):
+        # Two docs whose base.name differs only at the position of the '_'.
+        # With an unescaped LIKE pattern ('%spike_sort%'), '_' matches the 'X'
+        # here and the decoy would be a false positive, diverging from the
+        # brute-force ``param1 in value`` path.
+        match_id = self._add(_make_doc("1" * 32, fields={"base.name": "spike_sort"}))
+        self._add(_make_doc("2" * 32, fields={"base.name": "spikeXsort"}))
+
+        ids = self.db.search(
+            Query("base.name", "contains_string", "spike_sort"), branch_id="a"
+        )
+
+        # SQL result must agree with the brute-force path: exactly one match.
+        self.assertEqual(ids, [match_id])
+
+    def test_contains_string_percent_is_not_a_wildcard(self):
+        # '%' in the search term must match a literal '%', not "any run".
+        match_id = self._add(_make_doc("3" * 32, fields={"base.name": "50%done"}))
+        self._add(_make_doc("4" * 32, fields={"base.name": "50something_elsedone"}))
+
+        ids = self.db.search(
+            Query("base.name", "contains_string", "50%done"), branch_id="a"
+        )
+
+        self.assertEqual(ids, [match_id])
+
+    def test_depends_on_like_pattern_escapes_wildcards(self):
+        # The (currently unreachable) SQL depends_on branch must LIKE-escape the
+        # dependency name so a '_' in it cannot act as a single-char wildcard.
+        struct = {
+            "field": "",
+            "operation": "depends_on",
+            "param1": "a_b",
+            "param2": "val",
+        }
+        sql = self.db._query_struct_to_sql_str(struct)
+
+        # The underscore is escaped and an ESCAPE clause is emitted.
+        self.assertIn("a\\_b", sql)
+        self.assertIn("ESCAPE", sql)
+
     # --- numeric op with a non-numeric param1: graceful fallback --------------
 
     def test_numeric_op_nonnumeric_param_does_not_raise(self):

--- a/tests/test_query_correctness.py
+++ b/tests/test_query_correctness.py
@@ -1,0 +1,139 @@
+"""Query-correctness tests for the SQLite leaf-query builder.
+
+These cover three narrowing/robustness fixes in
+``SQLiteDB._query_struct_to_sql_str`` / ``_search_doc_ids``:
+
+* ``hasfield`` must not let an underscore in the field name act as a LIKE
+  single-character wildcard (e.g. querying ``a_b`` must not match ``axb``).
+* ``isa`` must not let a regex metacharacter in the class name act as a
+  wildcard in the ``meta.superclass`` regexp (e.g. ``foo.bar`` must not match
+  ``fooxbar``).
+* A numeric operation given a non-numeric ``param1`` must fall back to
+  brute-force search instead of raising and aborting the whole query.
+"""
+
+import os
+import unittest
+
+from did.document import Document
+from did.query import Query
+from did.implementations.sqlitedb import SQLiteDB
+
+
+def _make_doc(idhex, *, fields=None, class_name=None, superclasses=None):
+    """Build a Document with explicit flattened fields / class metadata.
+
+    ``fields`` is a mapping of dotted field name -> value placed verbatim into
+    the document properties so that ``doc2sql`` stores those exact field names.
+    ``superclasses`` (a list of plain strings) populates ``meta.superclass`` as
+    a comma-space joined list without any path stripping.
+    """
+    props = {
+        "base": {"id": idhex, "datestamp": "2020-01-01"},
+        "document_class": {"class_name": class_name or "thing"},
+    }
+    if superclasses is not None:
+        props["superclasses"] = list(superclasses)
+    if fields:
+        for dotted, value in fields.items():
+            group, _, leaf = dotted.partition(".")
+            props.setdefault(group, {})
+            if leaf:
+                props[group][leaf] = value
+            else:
+                props[group] = value
+    return Document(props)
+
+
+class TestQueryCorrectness(unittest.TestCase):
+    DB_FILENAME = "test_query_correctness.sqlite"
+
+    def setUp(self):
+        if os.path.exists(self.DB_FILENAME):
+            os.remove(self.DB_FILENAME)
+        self.db = SQLiteDB(self.DB_FILENAME)
+        self.db.add_branch("a")
+
+    def tearDown(self):
+        self.db._close_db()
+        if os.path.exists(self.DB_FILENAME):
+            os.remove(self.DB_FILENAME)
+
+    def _add(self, doc):
+        self.db._do_add_doc(doc, "a")
+        return doc.id()
+
+    # --- hasfield: '_' must not behave as a LIKE wildcard ---------------------
+
+    def test_hasfield_underscore_is_not_a_wildcard(self):
+        # Document whose subfield lives under the underscored group 'a_b'.
+        match_id = self._add(_make_doc("1" * 32, fields={"a_b.value": 1}))
+        # Decoy whose group 'axb' differs only at the position of the '_'.
+        # With an unescaped LIKE pattern ('a_b.%'), '_' matches the 'x' here and
+        # this document would be a false positive.
+        self._add(_make_doc("2" * 32, fields={"axb.value": 2}))
+
+        ids = self.db.search(Query("a_b", "hasfield"), branch_id="a")
+
+        self.assertEqual(ids, [match_id])
+
+    def test_hasfield_exact_underscored_field(self):
+        # The exact (non-subfield) branch must still match an underscored field.
+        match_id = self._add(_make_doc("3" * 32, fields={"a_b.value": 1}))
+        self._add(_make_doc("4" * 32, fields={"axb.value": 2}))
+
+        ids = self.db.search(Query("a_b.value", "hasfield"), branch_id="a")
+
+        self.assertEqual(ids, [match_id])
+
+    # --- isa: regex metacharacters in the class name must be escaped ----------
+
+    def test_isa_dot_is_not_a_regex_wildcard(self):
+        # 'meta.superclass' for this doc holds two list elements that differ
+        # only at the position of the '.': 'foo.bar' and 'fooxbar'.
+        match_id = self._add(_make_doc("5" * 32, superclasses=["foo.bar", "fooxbar"]))
+        # A doc carrying only the decoy superclass must never match 'foo.bar'.
+        self._add(_make_doc("6" * 32, superclasses=["fooxbar"]))
+
+        ids = self.db.search(Query("", "isa", "foo.bar"), branch_id="a")
+
+        self.assertEqual(ids, [match_id])
+
+    def test_isa_dot_class_does_not_match_decoy_only(self):
+        # A document whose only superclass is the decoy 'fooxbar' must produce
+        # the empty result for an isa('foo.bar') query.
+        self._add(_make_doc("7" * 32, superclasses=["fooxbar"]))
+
+        ids = self.db.search(Query("", "isa", "foo.bar"), branch_id="a")
+
+        self.assertEqual(ids, [])
+
+    # --- numeric op with a non-numeric param1: graceful fallback --------------
+
+    def test_numeric_op_nonnumeric_param_does_not_raise(self):
+        # A genuinely numeric field plus a non-numeric comparison value used to
+        # raise ValueError from float() and abort the entire search. It must now
+        # fall back to brute force and simply return no matches.
+        self._add(_make_doc("8" * 32, fields={"demoA.value": 5}))
+
+        ids = self.db.search(
+            Query("demoA.value", "lessthan", "not-a-number"), branch_id="a"
+        )
+
+        self.assertEqual(ids, [])
+
+    def test_numeric_op_nonnumeric_param_in_compound_query(self):
+        # The bad numeric leaf must not poison an OR'd query: the search should
+        # complete and return the matches from the well-formed branch.
+        good_id = self._add(_make_doc("9" * 32, fields={"demoA.value": 5}))
+
+        q = Query("demoA.value", "exact_number", "oops") | Query(
+            "demoA.value", "exact_number", 5
+        )
+        ids = self.db.search(q, branch_id="a")
+
+        self.assertEqual(ids, [good_id])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cross-fork: `audriB/DID-python:exp/backend-hardening-2026-07` (`619d2c9`) → `VH-Lab/DID-python:main` (`361df8d`, unchanged since 2026-06-14). **+16 / −0, 0 behind** — no rebase risk. The 14 hardening commits are 17 files, +1103/−84; the 2 lint commits on top are `pyproject.toml` plus 3 test files (+3/−3).

## Gate results (CI-equivalent tooling, run before and after)

| Gate | Before | After |
|---|---|---|
| `pytest` (the CI command, `testpaths=tests`) | 105p / 1s / 1xf | **105 passed, 1 skipped, 1 xfailed** |
| `pytest -m "not symmetry"` | — | **103 passed, 3 deselected, 1 xfailed** |
| `black --check src/ tests/` | green | **green**, 46 files unchanged |
| `ruff check src/ tests/` — this branch | **60 errors** | **0 — "All checks passed!"** |
| `ruff check src/ tests/` — main's code, new config | **59 errors** | **0 — verified two ways** |

Toolchain: `black 26.5.1` (CPython 3.12.0), `ruff 0.16.4`, `pytest 9.1.1` — exactly what this repo's unpinned `pip install ruff black` resolves today. Tests were run with `PYTHONPATH=$PWD/src` to replicate CI's `pip install -e`; a stale non-editable `did` in the scratch venv otherwise shadows the working tree (it even contains modules that do not exist here — `db.py`, `documentservice.py`, `fun.py`) and would report a confident, meaningless green.

The 1 skip is the absent-MATLAB-artifact case at `tests/symmetry/read_artifacts/database/test_build_database.py:36`; CI sets `DID_SYMMETRY_REQUIRE_ARTIFACTS=1`, so it fails hard there rather than skipping green. (`.gitlab-ci.yml` is 0 bytes — the only real gate is `.github/workflows/python-package.yml`.)

## Hardening content (14 commits)

- **SQLite LIKE/regexp metacharacter escaping** — `d9af6a8` in `hasfield`/`isa`, `8218840` in `contains_string`/`depends_on`. A `%` or `_` in caller data silently widened the match set.
- **`get_docs` IN-clause chunking** (`37d7806`) — queries above SQLite's variable limit failed rather than paging.
- **`_do_add_doc` made atomic and `OnDuplicate`-honoring** (`e72551f`).
- **`binarydoc_matfid` fails loud** (`a98dd8b`) — unimplemented paths used an uninitialized `Fileobj` instead of raising.
- **Wheel packaging** (`657c841`) — `example_schema/**/*.json` now ships in the wheel, backed by a dedicated `wheel-smoke` CI job that constructs a `Document` from outside the repo. Without it the installed package was unusable for anything schema-backed.

## Read this before the ruff gate: 59 of the 60 errors were not this branch's

`ruff check` here resolves *"Using Ruff default settings"* — there is no `[tool.ruff]` in `pyproject.toml` and no `ruff.toml` — and both CI jobs `pip install ruff` **unpinned**. Ruff's default rule set has widened since this gate was written (I001/UP024/SIM/BLE/DTZ/S/RUF/FURB now fire), so `main` itself measures **59 errors** under the same binary. This branch measured 60: net **+1**, being 3 new `I001` in its own new test files, offset by −1 DTZ003 and −1 PIE790. Nobody had noticed because `python-package.yml` only fires on pushes/PRs to `main`.

Fixed both halves rather than asking you to squint at a 60-error wall:

1. `2a54a09` sorts imports in the branch's three new test files (branch I001 25 → 22, i.e. equal to main).
2. `619d2c9` adds `[tool.ruff.lint] select = ["E4","E7","E9","F"]` — ruff's own pre-widening default. **Verified 0-on-main two ways**: `--config` against a detached `origin/main` worktree, and by physically grafting the block into main's own `pyproject.toml`. Under ruff's *wide* default this branch now reads 57 against main's 59 — strictly better than main even ungated.

`[tool.ruff.lint]` rather than a top-level `select` because the top-level form is deprecated in 0.16.4 and emits a warning; with ruff unpinned that is the same drift problem returning by another route.

Two constraints that shaped the rule choice, both measured:

- **E501 and `black --check` cannot both be green in this repo at any limit.** Main has 38 lines over 88 and 23 over even 100 (long strings/URLs black will not split). The plausible-looking `E,W,F,I,B,C4,UP` set scores **82 errors on main at 88, 67 at 100** — worse than the 59 status quo. Excluding E501 is load-bearing, not fastidiousness.
- **No black config exists in this repo at all** (no `[tool.black]`, `setup.cfg`, `tox.ini`, or `ruff.toml`), so black runs at its default 88. I set no line-length rather than invent a convention nothing enforces.

### The import-sort fix is correct hygiene but is NOT gate-enforced

`I` had to stay out of `select`: main carries **22 genuinely unsorted import blocks** (verified by diff — plain alphabetical disorder, e.g. `import unittest` before `import os`), not a `known-first-party` misconfiguration, so no isort knob fixes it. Including `I` meant either 22-file churn on main or ~20 lines of `per-file-ignores`. Clean follow-up if you want it: one dedicated `ruff check --select I --fix` commit on `main`, landed *before* this PR, after which `I` can be added here in one line.

## Consumers

NDI-python's catch-up PR pins this fork at `6093683` — the 14-commit hardening head, i.e. this branch minus the two lint commits. `ndi-data-browser-v2`'s Dockerfile is re-pinned to the same SHA (it was stuck at `d9af6a8`, on the right branch but 11 commits below the tip). Nothing functional differs between `6093683` and this PR head; **flip both pins to a VH-Lab `main` SHA once this merges.**

## Not in this PR

- Enabling ruff's `I` rule, and the 22-file import sweep on `main` it requires.
- Any line-length / E501 convention for this repo.
- MATLAB symmetry execution — `symmetry.yml` checks out sibling MATLAB repos and calls the GitHub API; not run locally.
- Schema-coupled work: deferred behind DID-schema V_eta.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
